### PR TITLE
Do not publish a container's port(s) to the host in tests

### DIFF
--- a/4/test/run
+++ b/4/test/run
@@ -52,7 +52,7 @@ prepare() {
 
 run_test_application() {
   run_args=${CONTAINER_ARGS:-}
-  docker run --user=100001 ${run_args} --cidfile=${cid_file} -p ${test_port} ${IMAGE_NAME}-testapp
+  docker run --user=100001 ${run_args} --cidfile=${cid_file} ${IMAGE_NAME}-testapp
 }
 
 cleanup_test_app() {


### PR DESCRIPTION
This may lead to conflicts with tests for different repository.


@hhorak Please take a look.