### PR TITLE
Update Dockerfiles

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -5,11 +5,24 @@ FROM centos/s2i-base-centos7
 EXPOSE 8080
 EXPOSE 8443
 
-LABEL io.k8s.description="Platform for running Varnish or building Varnish-based application" \
+ENV SUMMARY="Platform for running Varnish or building Varnish-based application" \
+    DESCRIPTION="Varnish available as docker container is a base platform for \
+running Varnish server or building Varnish-based application. \
+Varnish Cache stores web pages in memory so web servers don't have to create \
+the same web page over and over again. Varnish Cache serves pages much faster \
+than any application server; giving the website a significant speed up."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Varnish 4" \
       io.openshift.expose-services="8080:http" \
       io.openshift.expose-services="8443:https" \
-      io.openshift.tags="builder,varnish,rh-varnish4"
+      io.openshift.tags="builder,varnish,rh-varnish4" \
+      com.redhat.component="rh-varnish4-docker" \
+      name="centos/varnish-4-centos7" \
+      version="4" \
+      release="1"
 
 ENV VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish4/varnish
 

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -27,7 +27,7 @@ LABEL summary="$SUMMARY" \
 ENV VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish4/varnish
 
 RUN yum install -y centos-release-scl-rh epel-release && \
-    INSTALL_PKGS="yum-utils gettext hostname nss_wrapper bind-utils rh-varnish4-jemalloc rh-varnish4-jemalloc-devel rh-varnish4-runtime rh-varnish4-scldevel rh-varnish4-varnish rh-varnish4-varnish-docs rh-varnish4-varnish-libs rh-varnish4-varnish-libs-devel" && \
+    INSTALL_PKGS="yum-utils gettext hostname nss_wrapper bind-utils rh-varnish4-varnish" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     rm -f /etc/profile.d/lang.sh && \

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -14,9 +14,9 @@ LABEL io.k8s.description="Platform for running Varnish or building Varnish-based
 ENV VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish4/varnish
 
 RUN yum install -y centos-release-scl-rh epel-release && \
-    yum install -y yum-utils gettext hostname && \
-    yum install -y --setopt=tsflags=nodocs nss_wrapper && \
-    yum install -y --setopt=tsflags=nodocs bind-utils rh-varnish4-* && \
+    INSTALL_PKGS="yum-utils gettext hostname nss_wrapper bind-utils rh-varnish4-build rh-varnish4-jemalloc rh-varnish4-jemalloc-devel rh-varnish4-runtime rh-varnish4-scldevel rh-varnish4-varnish rh-varnish4-varnish-docs rh-varnish4-varnish-libs rh-varnish4-varnish-libs-devel" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
     rm -f /etc/profile.d/lang.sh && \
     rm -f /etc/profile.d/lang.csh && \
     yum clean all

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -27,7 +27,7 @@ LABEL summary="$SUMMARY" \
 ENV VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish4/varnish
 
 RUN yum install -y centos-release-scl-rh epel-release && \
-    INSTALL_PKGS="yum-utils gettext hostname nss_wrapper bind-utils rh-varnish4-build rh-varnish4-jemalloc rh-varnish4-jemalloc-devel rh-varnish4-runtime rh-varnish4-scldevel rh-varnish4-varnish rh-varnish4-varnish-docs rh-varnish4-varnish-libs rh-varnish4-varnish-libs-devel" && \
+    INSTALL_PKGS="yum-utils gettext hostname nss_wrapper bind-utils rh-varnish4-jemalloc rh-varnish4-jemalloc-devel rh-varnish4-runtime rh-varnish4-scldevel rh-varnish4-varnish rh-varnish4-varnish-docs rh-varnish4-varnish-libs rh-varnish4-varnish-libs-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     rm -f /etc/profile.d/lang.sh && \

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -5,18 +5,24 @@ FROM rhscl/s2i-base-rhel7:1
 EXPOSE 8080
 EXPOSE 8443
 
-LABEL io.k8s.description="Platform for running Varnish or building Varnish-based application" \
+ENV SUMMARY="Platform for running Varnish or building Varnish-based application" \
+    DESCRIPTION="Varnish available as docker container is a base platform for \
+running Varnish server or building Varnish-based application. \
+Varnish Cache stores web pages in memory so web servers don't have to create \
+the same web page over and over again. Varnish Cache serves pages much faster \
+than any application server; giving the website a significant speed up."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Varnish 4" \
       io.openshift.expose-services="8080:http" \
       io.openshift.expose-services="8443:https" \
-      io.openshift.tags="builder,varnish,rh-varnish4"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-varnish4-docker" \
+      io.openshift.tags="builder,varnish,rh-varnish4" \
+      com.redhat.component="rh-varnish4-docker" \
       name="rhscl/varnish-4-rhel7" \
       version="4" \
-      release="12.1" \
-      architecture="x86_64"
+      release="12.1"
 
 ENV VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish4/varnish
 

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -20,12 +20,13 @@ LABEL com.redhat.component="rh-varnish4-docker" \
 
 ENV VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish4/varnish
 
-RUN yum install -y yum-utils gettext hostname && \
+RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
-    yum install -y --setopt=tsflags=nodocs nss_wrapper && \
-    yum install -y --setopt=tsflags=nodocs bind-utils rh-varnish4-* && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish4-build rh-varnish4-jemalloc rh-varnish4-jemalloc-devel rh-varnish4-runtime rh-varnish4-scldevel rh-varnish4-varnish rh-varnish4-varnish-docs rh-varnish4-varnish-libs rh-varnish4-varnish-libs-devel" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
     rm -f /etc/profile.d/lang.sh && \
     rm -f /etc/profile.d/lang.csh && \
     yum clean all

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -30,7 +30,7 @@ RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish4-jemalloc rh-varnish4-jemalloc-devel rh-varnish4-runtime rh-varnish4-scldevel rh-varnish4-varnish rh-varnish4-varnish-docs rh-varnish4-varnish-libs rh-varnish4-varnish-libs-devel" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish4-varnish" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     rm -f /etc/profile.d/lang.sh && \

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -30,7 +30,7 @@ RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish4-build rh-varnish4-jemalloc rh-varnish4-jemalloc-devel rh-varnish4-runtime rh-varnish4-scldevel rh-varnish4-varnish rh-varnish4-varnish-docs rh-varnish4-varnish-libs rh-varnish4-varnish-libs-devel" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish4-jemalloc rh-varnish4-jemalloc-devel rh-varnish4-runtime rh-varnish4-scldevel rh-varnish4-varnish rh-varnish4-varnish-docs rh-varnish4-varnish-libs rh-varnish4-varnish-libs-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     rm -f /etc/profile.d/lang.sh && \


### PR DESCRIPTION
Provide same labels for all base image variants (CentOS, RHEL)
 - follow recomended labels from Project Atomic Container best practices
 - add summary and description labels - use ENV for simple using of same value in more descriptive labels
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
                                           
(don't use separate instruction for each label)

Verify installed packages by `rpm -V`.

@hhorak @praiskup @pkubatrh Please take a look and merge.