### PR TITLE
tests: replace removed s2i flag

### DIFF
--- a/4/test/run
+++ b/4/test/run
@@ -174,7 +174,7 @@ cid_file=$(mktemp -u --suffix=.cid)
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 prepare
 run_s2i_build


### PR DESCRIPTION
Similarily to: sclorg/s2i-python-container#229