### PR TITLE
Missing gcc -> tests fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # help.1 files complied by container-common-scripts from README.md files
 */root/help.1
-
+.*image-id*

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -27,7 +27,7 @@ LABEL summary="$SUMMARY" \
 ENV VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish4/varnish
 
 RUN yum install -y centos-release-scl-rh epel-release && \
-    INSTALL_PKGS="yum-utils gettext hostname nss_wrapper bind-utils rh-varnish4-varnish" && \
+    INSTALL_PKGS="yum-utils gettext hostname nss_wrapper bind-utils rh-varnish4-varnish gcc" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     rm -f /etc/profile.d/lang.sh && \

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -31,7 +31,7 @@ RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish4-varnish" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish4-varnish gcc" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     rm -f /etc/profile.d/lang.sh && \


### PR DESCRIPTION
FIX:
Enable `devtoolset-4` SCL by default - `rh-varnish4-varnish` requires gcc and it is provided by `devtoolset-4-gcc`.

Also update build scripts.

@pkubatrh @hhorak Please take a look and if it is fine merge.