### PR TITLE
Fix permissions for all files given in s2i

### DIFF
--- a/src/s2i/bin/assemble
+++ b/src/s2i/bin/assemble
@@ -6,6 +6,10 @@ echo "---> Copying varnish configuration files..."
 rm -rf "${VARNISH_CONFIGURATION_PATH}/default.vcl"
 cp -Rfv /tmp/src/. "${VARNISH_CONFIGURATION_PATH}"
 
+# Fix source directory permissions
+fix-permissions ./
+fix-permissions ${VARNISH_CONFIGURATION_PATH}
+
 if [ ! -f "${VARNISH_CONFIGURATION_PATH}/default.vcl" ]; then
     echo "Error: The varnish configuration must contain 'default.vcl' file."
     exit 1


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Adds fix-permissions right after cp and add -a to cp command.


Reference issue:
https://github.com/sclorg/container-common-scripts/issues/119
