### PR TITLE
Fix fedora build

### DIFF
--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -4,8 +4,8 @@ specs:
   distroinfo:
     fedora:
       distros:
-        - fedora-28-x86_64
-      s2i_base: registry.fedoraproject.org/f28/s2i-core:latest
+        - fedora-31-x86_64
+      s2i_base: registry.fedoraproject.org/f31/s2i-core:latest
       install_pkgs: "gettext hostname nss_wrapper bind-utils varnish"
       img_name: "$FGC/varnish"
       etc_path: /etc
@@ -50,7 +50,6 @@ specs:
   version:
     "4":
       version: "4"
-
     "5":
       version: "5"
     "6":
@@ -59,13 +58,10 @@ specs:
 matrix:
   exclude:
     - distros:
-        - fedora-28-x86_64
+        - fedora-31-x86_64
         - rhel-8-x86_64
       version: "4"
     - distros:
         - rhel-8-x86_64
+        - fedora-31-x86_64
       version: "5"
-    - distros:
-        - fedora-28-x86_64
-      version: "6"
-


### PR DESCRIPTION
This PR fixes Fedora builds.

Fedora container is not built for version 5. Varnish 6 is available since Fedora 30.