### PR TITLE
Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/test/imagestreams
+++ b/test/imagestreams
@@ -1,0 +1,1 @@
+../imagestreams/

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -21,7 +21,7 @@ ct_os_check_compulsory_vars
 ct_os_cluster_up
 
 # test with the just built image and an integrated template
-test_varnish_integration "${IMAGE_NAME}" "${VERSION}" varnish
+test_varnish_integration "${IMAGE_NAME}"
 
 # test with a released image and an integrated template
 if [ "${OS}" == "rhel7" ] ; then
@@ -31,7 +31,7 @@ else
 fi
 
 export CT_SKIP_UPLOAD_IMAGE=true
-test_varnish_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" varnish
+test_varnish_integration "${PUBLIC_IMAGE_NAME}"
 
 # Check the imagestream
 test_varnish_imagestream

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -25,13 +25,16 @@ test_varnish_integration "${IMAGE_NAME}" "${VERSION}" varnish
 
 # test with a released image and an integrated template
 if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.access.redhat.com/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
+  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
 else
   PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
 fi
 
 export CT_SKIP_UPLOAD_IMAGE=true
-test_varnish_integration varnish "${VERSION}" "${PUBLIC_IMAGE_NAME}"
+test_varnish_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" varnish
+
+# Check the imagestream
+test_varnish_imagestream
 
 OS_TESTSUITE_RESULT=0
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -24,17 +24,20 @@ ct_os_cluster_up
 test_varnish_integration "${IMAGE_NAME}"
 
 # test with a released image and an integrated template
-if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
-else
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
-fi
-
-export CT_SKIP_UPLOAD_IMAGE=true
-test_varnish_integration "${PUBLIC_IMAGE_NAME}"
+PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-$(ct_get_public_image_name "${OS}" "${BASE_IMAGE_NAME}" "${VERSION}")}
 
 # Check the imagestream
 test_varnish_imagestream
+
+# Try pulling the image first to see if it is accessible
+if docker pull "${PUBLIC_IMAGE_NAME}"; then
+  export CT_SKIP_UPLOAD_IMAGE=true
+  test_varnish_integration "${PUBLIC_IMAGE_NAME}"
+else
+  echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
+  # ignore possible failure of this test for centos images
+  [ "${OS}" == "rhel7" ] && false "ERROR: Failed to pull image"
+fi
 
 OS_TESTSUITE_RESULT=0
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,7 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_varnish_integration "${IMAGE_NAME}" "${VERSION}" varnish
+test_varnish_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_varnish_imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,10 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_varnish_integration varnish ${VERSION} "${IMAGE_NAME}"
+test_varnish_integration "${IMAGE_NAME}" "${VERSION}" varnish
+
+# Check the imagestream
+test_varnish_imagestream
 
 OS_TESTSUITE_RESULT=0
 

--- a/test/test-lib-varnish.sh
+++ b/test/test-lib-varnish.sh
@@ -53,7 +53,6 @@ function test_response_redirect_internal() {
 
 function test_varnish_integration() {
   local image_name=$1
-  local version=$2
   ct_os_test_s2i_app_func "${image_name}" \
                           "https://github.com/sclorg/varnish-container.git" \
                           "test/test-app" \

--- a/test/test-lib-varnish.sh
+++ b/test/test-lib-varnish.sh
@@ -58,9 +58,38 @@ function test_varnish_integration() {
   VERSION=$version ct_os_test_s2i_app_func "${image_name}" \
                                            "https://github.com/sclorg/varnish-container.git" \
                                            test/test-app \
-                                           "test_response_redirect_internal 'http://<IP>:8080' '301' 'oldexample.com' 'http://example.org'" \
-                                           "" \
-                                           "${import_image}"
+                                           "test_response_redirect_internal 'http://<IP>:8080' '301' 'oldexample.com' 'http://example.org'"
 }
 
+# Check the imagestream
+function test_varnish_imagestream() {
+  local image_stream_file
+  local local_image_stream_file
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  image_stream_file="${THISDIR}/imagestreams/varnish-${OS}.json"
+  echo "Running image stream test for stream ${image_stream_file} and test application"
+
+  # shellcheck disable=SC2119
+  ct_os_new_project
+
+  local_image_stream_file=$(ct_obtain_input "${image_stream_file}")
+  oc create -f "${local_image_stream_file}"
+
+  # ct_os_test_s2i_app creates a new project, but we already need
+  # it before for the image stream import, so tell it to skip this time
+  CT_SKIP_NEW_PROJECT=true \
+  ct_os_test_s2i_app_func "${IMAGE_NAME}" \
+                          "https://github.com/sclorg/varnish-container.git" \
+                          test/test-app \
+                          "test_response_redirect_internal 'http://<IP>:8080' '301' 'oldexample.com' 'http://example.org'"
+
+  result=$?
+
+  # shellcheck disable=SC2119
+  ct_os_delete_project
+}
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test/test-lib-varnish.sh
+++ b/test/test-lib-varnish.sh
@@ -54,11 +54,10 @@ function test_response_redirect_internal() {
 function test_varnish_integration() {
   local image_name=$1
   local version=$2
-  local import_image=$3
-  VERSION=$version ct_os_test_s2i_app_func "${image_name}" \
-                                           "https://github.com/sclorg/varnish-container.git" \
-                                           test/test-app \
-                                           "test_response_redirect_internal 'http://<IP>:8080' '301' 'oldexample.com' 'http://example.org'"
+  ct_os_test_s2i_app_func "${image_name}" \
+                          "https://github.com/sclorg/varnish-container.git" \
+                          "test/test-app" \
+                          "test_response_redirect_internal 'http://<IP>:8080' '301' 'oldexample.com' 'http://example.org'"
 }
 
 # Check the imagestream


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster
