### PR TITLE
Support quay io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Varnish HTTP accelerator container images
-======================================
+=========================================
+
+Varnish 5 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/varnish-5-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/varnish-5-centos7), Varnish 6 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/varnish-6-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/varnish-6-centos7)
 
 This repository contains Dockerfiles for Varnish HTTP accelerator images for OpenShift.
 Users can choose between RHEL, CentOS and Fedora based images.
@@ -51,7 +53,7 @@ To build a Varnish image, choose either the CentOS or RHEL based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ podman pull centos/varnish-6-centos7
+    $ podman pull quay.io/centos7/varnish-6-centos7
     ```
 
     To build a Varnish image from scratch run:
@@ -82,13 +84,13 @@ on all provided versions of Varnish.**
 
 
 Contributing
---------------------------------
+------------
 
 In this repository [distgen](https://github.com/devexp-db/distgen/) is used for generating image source files. If you'd like update a Dockerfile, please make changes in specs/multispec.yml and/or Dockerfile.template (or other distgen file) and run `make generate`.
 
 
 Usage
----------------------------------
+-----
 For information about usage of Dockerfile for Varnish 5,
 see [usage documentation](https://github.com/sclorg/varnish-container/tree/generated/5).
 
@@ -96,7 +98,7 @@ For information about usage of Dockerfile for Varnish 6,
 see [usage documentation](https://github.com/sclorg/varnish-container/tree/generated/6).
 
 Test
----------------------
+----
 This repository also provides a [S2I](https://github.com/openshift/source-to-image) test framework,
 which launches tests to check functionality of a simple Varnish application built on top of the Varnish image.
 

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -13,7 +13,6 @@ specs:
       distros:
         - centos-7-x86_64
       s2i_base: quay.io/centos7/s2i-core-centos7
-      from_tag: "1"
       install_pkgs: "gettext hostname nss_wrapper bind-utils rh-varnish{{ spec.version }}-varnish gcc"
       org: "centos7"
       prod: "centos7"

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -12,12 +12,12 @@ specs:
     centos:
       distros:
         - centos-7-x86_64
-      s2i_base: centos/s2i-core-centos7
+      s2i_base: quay.io/centos7/s2i-core-centos7
       from_tag: "1"
       install_pkgs: "gettext hostname nss_wrapper bind-utils rh-varnish{{ spec.version }}-varnish gcc"
-      org: "centos"
+      org: "centos7"
       prod: "centos7"
-      img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
+      img_name: "quay.io/{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
       repo_setup: yum install -y centos-release-scl-rh && \
       staging_repo_setup: >-4
           yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-varnish{{ spec.version }}-rh-candidate/x86_64/os/ && \

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -1,5 +1,5 @@
 {% import "src/macros.tpl" as macros with context %}
-FROM {{ spec.s2i_base}}{% if spec.from_tag %}:{{ spec.from_tag }}{% endif %}
+FROM {{ spec.s2i_base }}{% if spec.from_tag %}:{{ spec.from_tag }}{% endif %}
 
 EXPOSE 8080
 EXPOSE 8443

--- a/src/README.md
+++ b/src/README.md
@@ -3,7 +3,7 @@ Varnish Cache {{ spec.version }}.0 HTTP reverse proxy Container image
 This container image includes Varnish {{ spec.version }}.0 Cache server and a reverse proxy for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -50,13 +50,13 @@ No further configuration is required.
 
 
 S2I build support
--------------
+-----------------
 The Varnish Cache {{ spec.version }}.0 Container image supports the S2I tool (see Usage section).
 Note that the default.vcl configuration file in the directory accessed by S2I needs 
 to be in the VCL format.
 
 Environment variables and volumes
--------------
+---------------------------------
 No special environment variables or volumes available.
 
 Troubleshooting


### PR DESCRIPTION
This commit adds support for Quay.io registry instead of Docker.io.
The reason for this is the rate limit introduced by Docker.io.