### PR TITLE
Support varnish container under OpenShift 4

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -10,19 +10,20 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-source ${THISDIR}/test-lib-varnish.sh
+source "${THISDIR}"/test-lib-varnish.sh
 
 set -eo nounset
 
 trap ct_os_cleanup EXIT SIGINT
 
+ct_os_set_ocp4
+
 ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
-export CT_SKIP_NEW_PROJECT=true
-export CT_SKIP_UPLOAD_IMAGE=true
-export CT_NAMESPACE=openshift
+# For testing on OpenShift 4 we use external registry
+export CT_EXTERNAL_REGISTRY=true
 
 test_varnish_integration "${IMAGE_NAME}"
 

--- a/test/test-lib-remote-openshift.sh
+++ b/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../common/test-lib-remote-openshift.sh

--- a/test/test-lib-varnish.sh
+++ b/test/test-lib-varnish.sh
@@ -8,8 +8,9 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-source ${THISDIR}/test-lib.sh
-source ${THISDIR}/test-lib-openshift.sh
+source "${THISDIR}"/test-lib.sh
+source "${THISDIR}"/test-lib-openshift.sh
+source "${THISDIR}"/test-lib-remote-openshift.sh
 
 function test_response_redirect_internal() {
   local url="$1"
@@ -25,7 +26,7 @@ function test_response_redirect_internal() {
   local status
   local response_code
   local response_file=$(mktemp /tmp/ct_test_response_XXXXXX)
-  local util_image_name='python:3.6'
+  local util_image_name='ubi7/ubi'
 
   ct_os_deploy_cmd_image "${util_image_name}"
 
@@ -68,7 +69,7 @@ function test_varnish_imagestream() {
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 
-  image_stream_file="${THISDIR}/imagestreams/varnish-${OS}.json"
+  image_stream_file="${THISDIR}/imagestreams/varnish-${OS%[0-9]*}.json"
   echo "Running image stream test for stream ${image_stream_file} and test application"
 
   # shellcheck disable=SC2119


### PR DESCRIPTION
This pull request adds the possibility to test varnish-container under OpenShift 4 environment.

For easy testing, just write down into the comment `[test-openshift-4]`