### PR TITLE
Deprecate Varnish 5 which reached EOL in May 2021

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in common/build.sh.
 BASE_IMAGE_NAME = varnish
-VERSIONS = 5 6
+VERSIONS = 6
 OPENSHIFT_NAMESPACES =
 DOCKER_BUILD_CONTEXT = ..
 

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -4,37 +4,11 @@ specs:
   distroinfo:
     fedora:
       distros:
-        - fedora-31-x86_64
-      s2i_base: registry.fedoraproject.org/f31/s2i-core:latest
+        - fedora-33-x86_64
+      s2i_base: registry.fedoraproject.org/f33/s2i-core:latest
       install_pkgs: "gettext hostname nss_wrapper bind-utils varnish"
       img_name: "$FGC/varnish"
       etc_path: /etc
-    centos:
-      distros:
-        - centos-7-x86_64
-      s2i_base: quay.io/centos7/s2i-core-centos7
-      install_pkgs: "gettext hostname nss_wrapper bind-utils rh-varnish{{ spec.version }}-varnish gcc"
-      org: "centos7"
-      prod: "centos7"
-      img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
-      repo_setup: yum install -y centos-release-scl-rh && \
-      staging_repo_setup: >-4
-          yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-varnish{{ spec.version }}-rh-candidate/x86_64/os/ && \
-              echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-varnish{{ spec.version }}-rh-candidate_x86_64_os_.repo && \
-      etc_path: /etc/opt/rh/rh-varnish{{ spec.version }}
-      var_path: /var/opt/rh/rh-varnish{{ spec.version }}
-    rhel7:
-      distros:
-        - rhel-7-x86_64
-      s2i_base: rhscl/s2i-core-rhel7
-      from_tag: "1"
-      install_pkgs: "gettext hostname nss_wrapper bind-utils rh-varnish{{ spec.version }}-varnish gcc"
-      org: "rhscl"
-      prod: "rhel7"
-      img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
-      repo_setup: prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-      etc_path: /etc/opt/rh/rh-varnish{{ spec.version }}
-      var_path: /var/opt/rh/rh-varnish{{ spec.version }}
     rhel8:
       distros:
         - rhel-8-x86_64
@@ -47,20 +21,5 @@ specs:
       etc_path: /etc
 
   version:
-    "4":
-      version: "4"
-    "5":
-      version: "5"
     "6":
       version: "6"
-
-matrix:
-  exclude:
-    - distros:
-        - fedora-31-x86_64
-        - rhel-8-x86_64
-      version: "4"
-    - distros:
-        - rhel-8-x86_64
-        - fedora-31-x86_64
-      version: "5"

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,8 @@
 Varnish Cache {{ spec.version }}.0 HTTP reverse proxy Container image
 =====================================================
+
+[![Docker Repository on Quay](https://quay.io/repository/centos7/varnish-{{ spec.version }}-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/varnish-{{ spec.version }}-centos7)
+
 This container image includes Varnish {{ spec.version }}.0 Cache server and a reverse proxy for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>