### PR TITLE
Add support for testing varnish-container on C9S

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -1,4 +1,4 @@
-name: docker-tests at Testing Farm
+name: container-tests at Testing Farm
 
 on:
   issue_comment:
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     # This job only runs for '[test]' pull request comments by owner, member
-    name: Docker tests on Testing Farm service
+    name: Container tests on Testing Farm service
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -17,26 +17,33 @@ jobs:
             os_test: "fedora"
             context: "Fedora"
             compose: "CentOS-7"
-            tmt_url: "http://artifacts.dev.testing-farm.io/"
+            tmt_url: "http://artifacts.dev.testing-farm.io"
             tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
           - tmt_plan: "centos7"
             os_test: "centos7"
             context: "CentOS7"
             compose: "CentOS-7"
-            tmt_url: "http://artifacts.dev.testing-farm.io/"
+            tmt_url: "http://artifacts.dev.testing-farm.io"
             tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
           - tmt_plan: "rhel7-docker"
             os_test: "rhel7"
             context: "RHEL7"
             compose: "RHEL-7.9-Released"
-            tmt_url: "http://artifacts.osci.redhat.com/testing-farm/"
+            tmt_url: "http://artifacts.osci.redhat.com/testing-farm"
             tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
           - tmt_plan: "rhel8-docker"
             os_test: "rhel8"
             context: "RHEL8"
             compose: "RHEL-8.3.1-Released"
-            tmt_url: "http://artifacts.osci.redhat.com/testing-farm/"
+            tmt_url: "http://artifacts.osci.redhat.com/testing-farm"
             tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
+          - tmt_plan: "c9s"
+            os_test: "c9s"
+            context: "CentOS Stream 9"
+            compose: "CentOS-Stream-9"
+            tmt_url: "http://artifacts.dev.testing-farm.io"
+            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
+
     if: |
       github.event.issue.pull_request
       && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
@@ -63,7 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Create a JSON file for Testing Farm in order to schedule a CI testing job
+          # Create a JSON data structure for GitHub API to display the test status in the PR
           cat << EOF > pending.json
           {
             "sha": "${{ steps.sha_value.outputs.SHA }}",
@@ -80,17 +87,16 @@ jobs:
             --data @pending.json
           echo "::set-output name=GITHUB_REPOSITORY::$GITHUB_REPOSITORY"
 
-      - name: Schedule a test on Testing Farm
+      - name: Schedule tests on Testing Farm
         id: sched_test
         run: |
           # Update ubuntu-20.04 in order to install curl and jq
           sudo apt update && sudo apt -y install curl jq
-          if [ "${{ matrix.tmt_plan }}" == "fedora" ] || [ "${{ matrix.tmt_plan }}" == "centos7" ]; then
+          api_key="${{ secrets.TF_INTERNAL_API_KEY }}"
+          branch_name="master"
+          if [ "${{ matrix.tmt_plan }}" == "fedora" ] || [ "${{ matrix.tmt_plan }}" == "centos7" ] || [ "${{ matrix.tmt_plan }}" == "c9s" ]; then
             api_key="${{ secrets.TF_PUBLIC_API_KEY }}"
             branch_name="main"
-          else
-            api_key="${{ secrets.TF_INTERNAL_API_KEY }}"
-            branch_name="master"
           fi
           cat << EOF > request.json
           {
@@ -109,6 +115,10 @@ jobs:
                 "PR_NUMBER": "${{ steps.pr_nr.outputs.PR_NR }}",
                 "OS": "${{ matrix.os_test }}",
                 "TEST_NAME": "test"
+              },
+              "secrets": {
+                "QUAY_USERNAME": "${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}",
+                "QUAY_TOKEN": "${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}"
               }
             }]
           }


### PR DESCRIPTION
This pull request adds support for testing `varnish-container` on CentOS Stream 9.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>