### PR TITLE
Support testing, building and pushing container for C9S

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -65,7 +65,7 @@ jobs:
           files: "${{ matrix.version }}/${{ matrix.dockerfile }}"
 
       - name: Build image
-        if: steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true'
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true' }}
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
         uses: redhat-actions/buildah-build@v2
@@ -76,7 +76,7 @@ jobs:
           tags: latest ${{ matrix.tag }} ${{ github.sha }}
 
       - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && ${{ matrix.registry_namespace == 'centos7' }}
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && matrix.registry_namespace == 'centos7' }}
         id: push-to-quay-centos7
         uses: redhat-actions/push-to-registry@v2.2
         with:
@@ -87,7 +87,7 @@ jobs:
           password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
 
       - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && ${{ matrix.registry_namespace != 'centos7' }}
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && matrix.registry_namespace != 'centos7' }}
         id: push-to-quay-sclorg
         uses: redhat-actions/push-to-registry@v2.2
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -10,6 +10,13 @@ jobs:
     strategy:
       matrix:
         version: [6]
+        include:
+          - dockerfile: "Dockerfile"
+            registry_namespace: "centos7"
+            tag: "centos7"
+          - dockerfile: "Dockerfile.c9s"
+            registry_namespace: "sclorg"
+            tag: "c9s"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -35,41 +42,65 @@ jobs:
           ver="${{ matrix.version }}"
           echo "::set-output name=SHORT_VER::${ver//./}"
 
-      - name: Check if dockerfile is present in version directory
+      - name: Login to Quay.io private registry
+        if: ${{ matrix.registry_namespace != 'centos7' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}
+
+      - name: Check if .exclude-${{ matrix.tag }} is present in version directory
+        id: check_exclude_file
+        # https://github.com/marketplace/actions/file-existence
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "${{ matrix.version }}/.exclude-${{ matrix.tag }}"
+
+      - name: Check if ${{ matrix.dockerfile }} is present in version directory
         id: check_dockerfile_file
         # https://github.com/marketplace/actions/file-existence
         uses: andstor/file-existence-action@v1
         with:
-          files: "${{ matrix.version }}/Dockerfile"
+          files: "${{ matrix.version }}/${{ matrix.dockerfile }}"
 
-      - name: Check if .exclude-centos7 is present in version directory
-        id: check_exclude_centos7_file
-        # https://github.com/marketplace/actions/file-existence
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ matrix.version }}/.exclude-centos7"
-
-      - name: Build CentOS7 image
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true'
+      - name: Build image
+        if: steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true'
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
         uses: redhat-actions/buildah-build@v2
         with:
-          dockerfiles: ${{ matrix.version }}/Dockerfile
-          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-centos7
+          dockerfiles: ${{ matrix.version }}/${{ matrix.dockerfile }}
+          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-${{ matrix.tag }}
           context: ${{ matrix.version }}
-          tags: latest 1 ${{ github.sha }}
+          tags: latest ${{ matrix.tag }} ${{ github.sha }}
 
-      - name: Push CentOS7 image to Quay.io
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true'
-        id: push-to-quay
+      - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
+        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && ${{ matrix.registry_namespace == 'centos7' }}
+        id: push-to-quay-centos7
         uses: redhat-actions/push-to-registry@v2.2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/centos7
+          registry: quay.io/${{ matrix.registry_namespace }}
           username: ${{ secrets.QUAY_IMAGE_BUILDER_USERNAME }}
           password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
 
+      - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
+        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && ${{ matrix.registry_namespace != 'centos7' }}
+        id: push-to-quay-sclorg
+        uses: redhat-actions/push-to-registry@v2.2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/${{ matrix.registry_namespace }}
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}
+
       - name: Print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        if: ${{ matrix.registry_namespace == 'centos7' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay-centos7.outputs.registry-paths }}"
+
+      - name: Print image url
+        if: ${{ matrix.registry_namespace != 'centos7' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay-sclorg.outputs.registry-paths }}"

--- a/6/Dockerfile.c9s
+++ b/6/Dockerfile.c9s
@@ -1,0 +1,49 @@
+FROM quay.io/sclorg/s2i-core-c9s:c9s
+EXPOSE 8080
+EXPOSE 8443
+
+ENV SUMMARY="Platform for running Varnish or building Varnish-based application" \
+    DESCRIPTION="Varnish available as container is a base platform for \
+running Varnish server or building Varnish-based application. \
+Varnish Cache stores web pages in memory so web servers don't have to create \
+the same web page over and over again. Varnish Cache serves pages much faster \
+than any application server; giving the website a significant speed up." \
+    VARNISH_VCL=/etc/varnish/default.vcl \
+    VARNISH_CONFIGURATION_PATH=/etc/varnish
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Varnish 6" \
+      io.openshift.expose-services="8080:http,8443:https" \
+      io.openshift.tags="builder,varnish6,varnish-6" \
+      com.redhat.component="varnish-6-container" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      version="1" \
+      usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ quay.io/sclorg/varnish-6-c9s sample-server" \
+      name="sclorg/varnish-6-c9s" \
+      maintainer="Uhliarik Lubos <luhliari@redhat.com>"
+
+RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils varnish gcc" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    fix-permissions $VARNISH_CONFIGURATION_PATH && \
+    fix-permissions /var/lib/varnish && \
+    rm -f /etc/profile.d/lang.sh && \
+    rm -f /etc/profile.d/lang.csh && \
+    yum -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY 6/s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY 6/root/ /
+
+RUN chmod -R a+rwx ${APP_ROOT}/etc && \
+    chown -R 1001:0 ${APP_ROOT}
+# Reset permissions of filesystem to default values
+RUN rpm-file-permissions
+
+USER 1001
+
+CMD $STI_SCRIPTS_PATH/usage


### PR DESCRIPTION
This pull request adds support for building, testing and pushing container `varnish-6` for CentOS Stream 9.

What is changed in Dockerfile.c9s?
See diff:
```bash
$ diff 6/Dockerfile.rhel8 6/Dockerfile.c9s
1c1
< FROM ubi8/s2i-core:1
---
> FROM quay.io/sclorg/s2i-core-c9s:c9s
23,24c23,24
<       usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ rhel8/varnish-6 sample-server" \
<       name="rhel8/varnish-6" \
---
>       usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ quay.io/sclorg/varnish-6-c9s sample-server" \
>       name="sclorg/varnish-6-c9s" \
28d27
<     yum -y module enable varnish:6  && \
```