### PR TITLE
Revert back varnish-6 for CentOS 7 and RHEL7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 Varnish HTTP accelerator container images
 =========================================
 
+Varnish 6 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/varnish-6-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/varnish-6-centos7)
+
 This repository contains Dockerfiles for Varnish HTTP accelerator images for OpenShift.
-Users can choose between RHEL and Fedora based images.
+Users can choose between RHEL, CentOS, CentOS Stream 9 and Fedora based images.
 
 
 Versions
@@ -11,6 +13,7 @@ Varnish versions currently provided are:
 * [varnish-6](./6)
 
 RHEL versions currently supported are:
+* RHEL7
 * RHEL8
 
 
@@ -23,7 +26,7 @@ For more information about concepts used in these container images, see the
 Installation
 ---------------
 To build a Varnish image, choose either the CentOS or RHEL based image:
-*  **RHEL based image**
+* **RHEL based image**
 
     These images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/rhel8/varnish-6/5ba0ae68bed8bd6ee8198613?container-tabs=overview).
     To download it run:
@@ -41,8 +44,23 @@ To build a Varnish image, choose either the CentOS or RHEL based image:
     $ git submodule update --init
     $ make build TARGET=rhel8 VERSIONS=6
     ```
+* **CentOS based image**
 
-*  **Fedora based image**
+    This image is available on DockerHub. To download it run:
+
+    ```
+    $ podman pull quay.io/centos7/varnish-6-centos7
+    ```
+
+    To build a Varnish image from scratch run:
+
+    ```
+    $ git clone --recursive https://github.com/sclorg/varnish-container.git
+    $ cd varnish-container
+    $ git submodule update --init
+    $ make build TARGET=centos7 VERSIONS=6
+
+* **Fedora based image**
 
     You need to build the Fedora variant locally:
 
@@ -78,7 +96,7 @@ which launches tests to check functionality of a simple Varnish application buil
 
 Users can choose between testing a Varnish test application based on a RHEL or CentOS image.
 
-*  **RHEL based image**
+* **RHEL based image**
 
     To test a RHEL8 based Varnish image, you need to run the test on a properly
     subscribed RHEL machine.
@@ -89,7 +107,15 @@ Users can choose between testing a Varnish test application based on a RHEL or C
     $ make test TARGET=rhel8 VERSIONS=6
     ```
 
-*  **Fedora based image**
+* **CentOS based image**
+
+   ```
+    $ cd varnish-container
+    $ git submodule update --init
+    $ make test TARGET=centos7 VERSIONS=6
+    ```
+
+* **Fedora based image**
 
     ```
     $ cd varnish-container

--- a/imagestreams/varnish-centos.json
+++ b/imagestreams/varnish-centos.json
@@ -30,6 +30,26 @@
       },
       {
         "annotations": {
+          "description": "Store web pages in memory so web servers don't have to create the same web page over and over again on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/varnish-container/blob/generated/6/README.md.",
+          "iconClass": "icon-varnish",
+          "openshift.io/display-name": "Varnish 6 Cache HTTP reverse proxy",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/varnish-container.git",
+          "supports": "varnish",
+          "tags": "builder,varnish",
+          "version": "6"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/centos7/varnish-6-centos7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "6"
+      },
+      {
+        "annotations": {
           "description": "Store web pages in memory so web servers don't have to create the same web page over and over again on CentOS 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/varnish-container/blob/generated/6/README.md.",
           "iconClass": "icon-varnish",
           "openshift.io/display-name": "Varnish 6 Cache HTTP reverse proxy (CentOS 8)",
@@ -47,6 +67,26 @@
           "type": "Local"
         },
         "name": "6-el8"
+      },
+      {
+        "annotations": {
+          "description": "Store web pages in memory so web servers don't have to create the same web page over and over again on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/varnish-container/blob/generated/6/README.md.",
+          "iconClass": "icon-varnish",
+          "openshift.io/display-name": "Varnish 6 Cache HTTP reverse proxy (CentOS 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/varnish-container.git",
+          "supports": "varnish",
+          "tags": "builder,varnish",
+          "version": "6"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/centos7/varnish-6-centos7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "6-el7"
       },
       {
         "annotations": {

--- a/imagestreams/varnish-rhel.json
+++ b/imagestreams/varnish-rhel.json
@@ -30,6 +30,26 @@
       },
       {
         "annotations": {
+          "description": "Store web pages in memory so web servers don't have to create the same web page over and over again on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/varnish-container/blob/generated/6/README.md.",
+          "iconClass": "icon-varnish",
+          "openshift.io/display-name": "Varnish 6 Cache HTTP reverse proxy (RHEL 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/varnish-container.git",
+          "supports": "varnish",
+          "tags": "builder,varnish",
+          "version": "6"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/varnish-6-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "6"
+      },
+      {
+        "annotations": {
           "description": "Store web pages in memory so web servers don't have to create the same web page over and over again on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/varnish-container/blob/generated/6/README.md.",
           "iconClass": "icon-varnish",
           "openshift.io/display-name": "Varnish 6 Cache HTTP reverse proxy (RHEL 8)",
@@ -47,6 +67,26 @@
           "type": "Local"
         },
         "name": "6-el8"
+      },
+      {
+        "annotations": {
+          "description": "Store web pages in memory so web servers don't have to create the same web page over and over again on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/varnish-container/blob/generated/6/README.md.",
+          "iconClass": "icon-varnish",
+          "openshift.io/display-name": "Varnish 6 Cache HTTP reverse proxy (RHEL 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/varnish-container.git",
+          "supports": "varnish",
+          "tags": "builder,varnish",
+          "version": "6"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/varnish-6-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "6-el7"
       },
       {
         "annotations": {

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -9,6 +9,32 @@ specs:
       install_pkgs: "gettext hostname nss_wrapper bind-utils varnish"
       img_name: "$FGC/varnish"
       etc_path: /etc
+    centos:
+      distros:
+        - centos-7-x86_64
+      s2i_base: quay.io/centos7/s2i-core-centos7
+      install_pkgs: "gettext hostname nss_wrapper bind-utils rh-varnish{{ spec.version }}-varnish gcc"
+      org: "centos7"
+      prod: "centos7"
+      img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
+      repo_setup: yum install -y centos-release-scl-rh && \
+      staging_repo_setup: >-4
+          yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-varnish{{ spec.version }}-rh-candidate/x86_64/os/ && \
+              echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-varnish{{ spec.version }}-rh-candidate_x86_64_os_.repo && \
+      etc_path: /etc/opt/rh/rh-varnish{{ spec.version }}
+      var_path: /var/opt/rh/rh-varnish{{ spec.version }}
+    rhel7:
+      distros:
+        - rhel-7-x86_64
+      s2i_base: rhscl/s2i-core-rhel7
+      from_tag: "1"
+      install_pkgs: "gettext hostname nss_wrapper bind-utils rh-varnish{{ spec.version }}-varnish gcc"
+      org: "rhscl"
+      prod: "rhel7"
+      img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
+      repo_setup: prepare-yum-repositories rhel-server-rhscl-7-rpms && \
+      etc_path: /etc/opt/rh/rh-varnish{{ spec.version }}
+      var_path: /var/opt/rh/rh-varnish{{ spec.version }}
     rhel8:
       distros:
         - rhel-8-x86_64


### PR DESCRIPTION
This Pull request deprecates version 6 for CentOS 7 and RHEL7.

CentOS 7 and RHEL 7 deprecation PR was here: https://github.com/sclorg/varnish-container/pull/78

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>