### PR TITLE
Support testing pushing c8s

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -24,12 +24,20 @@ jobs:
             dockerfile: "Dockerfile.c9s"
             registry_namespace: "sclorg"
             tag: "c9s"
+            suffix: "c9s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+          - dockerfile_path: "6"
+            dockerfile: "Dockerfile.c8s"
+            registry_namespace: "sclorg"
+            tag: "c8s"
+            suffix: "c8s"
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
 
     steps:
       - name: Build and push to quay.io registry
-        uses: sclorg/build-and-push-action@v1
+        uses: sclorg/build-and-push-action@v2
         with:
           registry: "quay.io"
           registry_namespace: ${{ matrix.registry_namespace }}
@@ -38,4 +46,5 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           dockerfile_path: ${{ matrix.dockerfile_path }}
           tag: ${{ matrix.tag }}
+          suffix: ${{ matrix.suffix }}
           use_distgen: "true"

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c9s:c9s
+FROM quay.io/centos7/s2i-core-centos7
 EXPOSE 8080
 EXPOSE 8443
 
@@ -8,8 +8,8 @@ running Varnish server or building Varnish-based application. \
 Varnish Cache stores web pages in memory so web servers don't have to create \
 the same web page over and over again. Varnish Cache serves pages much faster \
 than any application server; giving the website a significant speed up." \
-    VARNISH_VCL=/etc/varnish/default.vcl \
-    VARNISH_CONFIGURATION_PATH=/etc/varnish
+    VARNISH_VCL=/etc/opt/rh/rh-varnish6/varnish/default.vcl \
+    VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish6/varnish
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
@@ -20,15 +20,14 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-varnish6-container" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       version="6" \
-      usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ sclorg/varnish-6-c9s sample-server" \
-      name="sclorg/varnish-6-c9s" \
+      usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ centos7/varnish-6-centos7 sample-server" \
+      name="centos7/varnish-6-centos7" \
       maintainer="Uhliarik Lubos <luhliari@redhat.com>"
 
-RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils varnish gcc" && \
+RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish6-varnish gcc rh-varnish6-varnish-modules" && \
+    yum install -y centos-release-scl-rh && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    fix-permissions $VARNISH_CONFIGURATION_PATH && \
-    fix-permissions /var/lib/varnish && \
     rm -f /etc/profile.d/lang.sh && \
     rm -f /etc/profile.d/lang.csh && \
     yum -y clean all --enablerepo='*'
@@ -39,11 +38,23 @@ COPY 6/s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY 6/root/ /
 
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
 RUN chmod -R a+rwx ${APP_ROOT}/etc && \
-    chown -R 1001:0 ${APP_ROOT}
+    chmod -R a+rwx /var/opt/rh/rh-varnish6 && \
+    chmod -R a+rwx /etc/opt/rh/rh-varnish6 && \
+    chown -R 1001:0 ${APP_ROOT} && \
+    chown -R 1001:0 /var/opt/rh/rh-varnish6 && \
+    chown -R 1001:0 /etc/opt/rh/rh-varnish6
 # Reset permissions of filesystem to default values
 RUN rpm-file-permissions
 
 USER 1001
 
+# VOLUME ["/etc/opt/rh/rh-varnish6/varnish"]
+
+ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
+    ENV=${APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
 CMD $STI_SCRIPTS_PATH/usage

--- a/6/Dockerfile.c8s
+++ b/6/Dockerfile.c8s
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c9s:c9s
+FROM quay.io/sclorg/s2i-core-c8s:c8s
 EXPOSE 8080
 EXPOSE 8443
 
@@ -20,11 +20,12 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-varnish6-container" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       version="6" \
-      usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ sclorg/varnish-6-c9s sample-server" \
-      name="sclorg/varnish-6-c9s" \
+      usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ sclorg/varnish-6-c8s sample-server" \
+      name="sclorg/varnish-6-c8s" \
       maintainer="Uhliarik Lubos <luhliari@redhat.com>"
 
 RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils varnish gcc" && \
+    yum -y module enable varnish:6  && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     fix-permissions $VARNISH_CONFIGURATION_PATH && \

--- a/6/Dockerfile.rhel7
+++ b/6/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c9s:c9s
+FROM rhscl/s2i-core-rhel7:1
 EXPOSE 8080
 EXPOSE 8443
 
@@ -8,8 +8,8 @@ running Varnish server or building Varnish-based application. \
 Varnish Cache stores web pages in memory so web servers don't have to create \
 the same web page over and over again. Varnish Cache serves pages much faster \
 than any application server; giving the website a significant speed up." \
-    VARNISH_VCL=/etc/varnish/default.vcl \
-    VARNISH_CONFIGURATION_PATH=/etc/varnish
+    VARNISH_VCL=/etc/opt/rh/rh-varnish6/varnish/default.vcl \
+    VARNISH_CONFIGURATION_PATH=/etc/opt/rh/rh-varnish6/varnish
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
@@ -20,15 +20,14 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-varnish6-container" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       version="6" \
-      usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ sclorg/varnish-6-c9s sample-server" \
-      name="sclorg/varnish-6-c9s" \
+      usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ rhscl/varnish-6-rhel7 sample-server" \
+      name="rhscl/varnish-6-rhel7" \
       maintainer="Uhliarik Lubos <luhliari@redhat.com>"
 
-RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils varnish gcc" && \
+RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils rh-varnish6-varnish gcc rh-varnish6-varnish-modules" && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    fix-permissions $VARNISH_CONFIGURATION_PATH && \
-    fix-permissions /var/lib/varnish && \
     rm -f /etc/profile.d/lang.sh && \
     rm -f /etc/profile.d/lang.csh && \
     yum -y clean all --enablerepo='*'
@@ -39,11 +38,23 @@ COPY 6/s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY 6/root/ /
 
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
 RUN chmod -R a+rwx ${APP_ROOT}/etc && \
-    chown -R 1001:0 ${APP_ROOT}
+    chmod -R a+rwx /var/opt/rh/rh-varnish6 && \
+    chmod -R a+rwx /etc/opt/rh/rh-varnish6 && \
+    chown -R 1001:0 ${APP_ROOT} && \
+    chown -R 1001:0 /var/opt/rh/rh-varnish6 && \
+    chown -R 1001:0 /etc/opt/rh/rh-varnish6
 # Reset permissions of filesystem to default values
 RUN rpm-file-permissions
 
 USER 1001
 
+# VOLUME ["/etc/opt/rh/rh-varnish6/varnish"]
+
+ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
+    ENV=${APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
 CMD $STI_SCRIPTS_PATH/usage

--- a/6/README.md
+++ b/6/README.md
@@ -6,7 +6,8 @@ Varnish Cache 6.0 HTTP reverse proxy Container image
 This container image includes Varnish 6.0 Cache server and a reverse proxy for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+the CentOS images are available on [Quay.io/centos7](https://quay.io/organization/centos7),
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -75,4 +76,6 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/varnish-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
 Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+for RHEL8 it's `Dockerfile.rhel8`, Dockerfile for CentOS Stream 8 is called `Dockerfile.c8s`,
+Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`
+and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 Varnish HTTP accelerator container images
 =========================================
 
+[![Build and push images to Quay.io registry](https://github.com/sclorg/varnish-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/varnish-container/actions/workflows/build-and-push.yml)
+
 Varnish 6 status:[![Docker Repository on Quay](https://quay.io/repository/centos7/varnish-6-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/varnish-6-centos7)
 
 This repository contains Dockerfiles for Varnish HTTP accelerator images for OpenShift.
-Users can choose between RHEL, CentOS, CentOS Stream 9 and Fedora based images.
+Users can choose between RHEL, CentOS, CentOS Stream 8, CentOS Stream 9 and Fedora based images.
 
 
 Versions
@@ -16,6 +18,9 @@ RHEL versions currently supported are:
 * RHEL7
 * RHEL8
 
+CentOS versions currently supported are:
+* CentOS Stream 8
+* CentOS Stream 9
 
 For more information about contributing, see
 [the Contribution Guidelines](https://github.com/sclorg/welcome/blob/master/contribution.md).

--- a/manifest.sh
+++ b/manifest.sh
@@ -40,6 +40,9 @@ DISTGEN_MULTI_RULES="
     dest=Dockerfile.rhel8;
 
     src=src/Dockerfile.template
+    dest=Dockerfile.c9s;
+
+    src=src/Dockerfile.template
     dest=Dockerfile.c8s;
 
     src=src/Dockerfile.template

--- a/manifest.sh
+++ b/manifest.sh
@@ -40,6 +40,9 @@ DISTGEN_MULTI_RULES="
     dest=Dockerfile.rhel8;
 
     src=src/Dockerfile.template
+    dest=Dockerfile.c8s;
+
+    src=src/Dockerfile.template
     dest=Dockerfile.fedora
 "
 

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -45,6 +45,18 @@ specs:
       repo_setup: yum -y module enable varnish:6  && \
       img_name: "{{ spec.prod }}/varnish-{{ spec.version }}"
       etc_path: /etc
+    c9s:
+      distros:
+        - centos-stream-9-x86_64
+      el_version: "9"
+      s2i_base: quay.io/sclorg/s2i-core-c9s
+      img_tag: "c9s"
+      org: "sclorg"
+      from_tag: "c9s"
+      prod: "c9s"
+      install_pkgs: "gettext hostname nss_wrapper bind-utils varnish gcc"
+      img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
+      etc_path: /etc
     c8s:
       distros:
         - centos-stream-8-x86_64

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -45,6 +45,19 @@ specs:
       repo_setup: yum -y module enable varnish:6  && \
       img_name: "{{ spec.prod }}/varnish-{{ spec.version }}"
       etc_path: /etc
+    c8s:
+      distros:
+        - centos-stream-8-x86_64
+      el_version: "8"
+      s2i_base: quay.io/sclorg/s2i-core-c8s
+      from_tag: "c8s"
+      img_tag: "c8s"
+      org: "sclorg"
+      prod: "c8s"
+      install_pkgs: "gettext hostname nss_wrapper bind-utils varnish gcc"
+      repo_setup: yum -y module enable varnish:6  && \
+      img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
+      etc_path: /etc
 
   version:
     "6":

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -31,7 +31,7 @@ RUN {{ macros.populate_install_pkgs(spec) }}
     {% endif %}
     {{ commands.pkginstaller.install([], {'docs': False}) }} $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    {% if config.os.id == "fedora" or spec.prod == "rhel8" or spec.prod == "c8s" %}
+    {% if config.os.id == "fedora" or spec.prod == "rhel8" or spec.prod == "c8s" or spec.prod == "c9s" %}
     fix-permissions $VARNISH_CONFIGURATION_PATH && \
     fix-permissions /var/lib/varnish && \
     {% endif %}
@@ -45,7 +45,7 @@ COPY {{ spec.version }}/s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY {{ spec.version }}/root/ /
 
-{% if config.os.id != "fedora" and spec.prod != "rhel8" and spec.prod != "c8s" %}
+{% if config.os.id != "fedora" and spec.prod != "rhel8" and spec.prod != "c8s" and spec.prod != "c9s" %}
 # In order to drop the root user, we have to make some directories world
 # writeable as OpenShift default security model is to run the container under
 # random UID.
@@ -64,7 +64,7 @@ RUN rpm-file-permissions
 
 USER 1001
 
-{% if config.os.id != "fedora" and spec.prod != "rhel8" and spec.prod != "c8s" %}
+{% if config.os.id != "fedora" and spec.prod != "rhel8" and spec.prod != "c8s" and spec.prod != "c9s" %}
 # VOLUME ["{{ spec.etc_path }}/varnish"]
 
 ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -31,7 +31,7 @@ RUN {{ macros.populate_install_pkgs(spec) }}
     {% endif %}
     {{ commands.pkginstaller.install([], {'docs': False}) }} $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    {% if config.os.id == "fedora" or spec.prod == "rhel8" %}
+    {% if config.os.id == "fedora" or spec.prod == "rhel8" or spec.prod == "c8s" %}
     fix-permissions $VARNISH_CONFIGURATION_PATH && \
     fix-permissions /var/lib/varnish && \
     {% endif %}
@@ -45,7 +45,7 @@ COPY {{ spec.version }}/s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY {{ spec.version }}/root/ /
 
-{% if config.os.id != "fedora" and spec.prod != "rhel8" %}
+{% if config.os.id != "fedora" and spec.prod != "rhel8" and spec.prod != "c8s" %}
 # In order to drop the root user, we have to make some directories world
 # writeable as OpenShift default security model is to run the container under
 # random UID.
@@ -64,7 +64,7 @@ RUN rpm-file-permissions
 
 USER 1001
 
-{% if config.os.id != "fedora" and spec.prod != "rhel8" %}
+{% if config.os.id != "fedora" and spec.prod != "rhel8" and spec.prod != "c8s" %}
 # VOLUME ["{{ spec.etc_path }}/varnish"]
 
 ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \

--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,8 @@ Varnish Cache {{ spec.version }}.0 HTTP reverse proxy Container image
 This container image includes Varnish {{ spec.version }}.0 Cache server and a reverse proxy for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+the CentOS images are available on [Quay.io/centos7](https://quay.io/organization/centos7),
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -75,4 +76,6 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/varnish-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
 Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+for RHEL8 it's `Dockerfile.rhel8`, Dockerfile for CentOS Stream 8 is called `Dockerfile.c8s`,
+Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`
+and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/src/macros.tpl
+++ b/src/macros.tpl
@@ -20,6 +20,9 @@
       com.redhat.component="varnish-{{ spec.version }}-container" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       version="1" \
+  {%- elif (spec.prod == "c8s" ) %}
+      io.openshift.tags="builder,varnish{{ spec.version }},varnish-{{ spec.version }}" \
+      version="1" \
   {%- else  %}
       io.openshift.tags="builder,varnish,rh-varnish{{ spec.version }}" \
       com.redhat.component="rh-varnish{{ spec.version }}-container" \

--- a/src/macros.tpl
+++ b/src/macros.tpl
@@ -20,9 +20,6 @@
       com.redhat.component="varnish-{{ spec.version }}-container" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       version="1" \
-  {%- elif (spec.prod == "c8s" ) %}
-      io.openshift.tags="builder,varnish{{ spec.version }},varnish-{{ spec.version }}" \
-      version="1" \
   {%- else  %}
       io.openshift.tags="builder,varnish,rh-varnish{{ spec.version }}" \
       com.redhat.component="rh-varnish{{ spec.version }}-container" \


### PR DESCRIPTION
This pull request adds support for testing, building, and pushing varnish-container in CentOS Stream 8.
It also updates documentation.

Difference between Dockerfile.rhel8 and Dockerfile.c8s:
```bash
diff 6/Dockerfile.rhel8 6/Dockerfile.c8s
1c1
< FROM ubi8/s2i-core:1
---
> FROM quay.io/sclorg/s2i-base-c8s:c8s
20,21d19
<       com.redhat.component="varnish-6-container" \
<       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
23,24c21,22
<       usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ rhel8/varnish-6 sample-server" \
<       name="rhel8/varnish-6" \
---
>       usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=6/test/test-app/ sclorg/varnish-6-c8s sample-server" \
>       name="sclorg/varnish-6-c8s" \
```

