### PR TITLE
Use Fedora-latest compose instead of CentOS-7 for Fedora tests

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -16,7 +16,7 @@ jobs:
           - tmt_plan: "fedora"
             os_test: "fedora"
             context: "Fedora"
-            compose: "CentOS-7"
+            compose: "Fedora-latest"
             api_key: "TF_PUBLIC_API_KEY"
             branch: "main"
             tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>