### PR TITLE
Support cvp

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -11,6 +11,7 @@
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source "${THISDIR}"/test-lib-varnish.sh
+source "${THISDIR}"/test-lib-remote-openshift.sh
 
 trap ct_os_cleanup EXIT SIGINT
 
@@ -24,6 +25,8 @@ ct_os_set_ocp4
 ct_os_check_compulsory_vars
 
 ct_os_check_login || exit 1
+
+ct_os_tag_image_for_cvp "varnish"
 
 set -u
 

--- a/test/test-lib-varnish.sh
+++ b/test/test-lib-varnish.sh
@@ -64,7 +64,7 @@ function test_varnish_imagestream() {
   local image_stream_file
   local local_image_stream_file
   case ${OS} in
-    rhel7|centos7) ;;
+    rhel7|centos7|rhel8) ;;
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 

--- a/test/test-openshift.yaml
+++ b/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../common/test-openshift.yaml


### PR DESCRIPTION
This pull request allows testing varnish-container in CVP pipeline.

The changes are:
* `common` directory is updated to the latest
* added link `test-openshift.yaml` from `common` directory
* added support for testing imagestreams on rhel8 in `test-lib-varnish.sh` file
* added support for tagging varnish image for CVP `run-openshift-remote-cluster`