### PR TITLE
container tests: the tests should be run with the 'u' bash option

### DIFF
--- a/test/run
+++ b/test/run
@@ -187,6 +187,8 @@ function _cleanup() {
   fi
 }
 
+set -u
+
 cid_file=$(mktemp -u --suffix=.cid)
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull


### PR DESCRIPTION
Partially solves: https://github.com/sclorg/varnish-container/issues/111