### PR TITLE
This pull request fixes issue 42

### DIFF
--- a/6/s2i/bin/assemble
+++ b/6/s2i/bin/assemble
@@ -2,9 +2,11 @@
 
 set -e
 
-echo "---> Copying varnish configuration files..."
+shopt -s dotglob
+echo "---> Installing application source..."
 rm -rf "${VARNISH_CONFIGURATION_PATH}/default.vcl"
-cp -Rfv /tmp/src/. "${VARNISH_CONFIGURATION_PATH}"
+rm -fR /tmp/src/.git
+mv /tmp/src/* "${VARNISH_CONFIGURATION_PATH}"
 
 # Fix source directory permissions
 fix-permissions ./

--- a/7/s2i/bin/assemble
+++ b/7/s2i/bin/assemble
@@ -2,9 +2,11 @@
 
 set -e
 
-echo "---> Copying varnish configuration files..."
+shopt -s dotglob
+echo "---> Installing application source..."
 rm -rf "${VARNISH_CONFIGURATION_PATH}/default.vcl"
-cp -Rfv /tmp/src/. "${VARNISH_CONFIGURATION_PATH}"
+rm -fR /tmp/src/.git
+mv /tmp/src/* "${VARNISH_CONFIGURATION_PATH}"
 
 # Fix source directory permissions
 fix-permissions ./

--- a/src/s2i/bin/assemble
+++ b/src/s2i/bin/assemble
@@ -2,9 +2,11 @@
 
 set -e
 
-echo "---> Copying varnish configuration files..."
+shopt -s dotglob
+echo "---> Installing application source..."
 rm -rf "${VARNISH_CONFIGURATION_PATH}/default.vcl"
-cp -Rfv /tmp/src/. "${VARNISH_CONFIGURATION_PATH}"
+rm -fR /tmp/src/.git
+mv /tmp/src/* "${VARNISH_CONFIGURATION_PATH}"
 
 # Fix source directory permissions
 fix-permissions ./


### PR DESCRIPTION
This pull request change assemble script so that sources are moved and not copied
as it is done in s2i-php-container or s2i-python-container 

See: https://github.com/sclorg/s2i-python-container/blob/master/src/s2i/bin/assemble#L62

Closes: #42 
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
