### PR TITLE
Support c10s

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Varnish HTTP accelerator container images
 
 Images available on Quay are:
 * CentOS Stream 9 [varnish-6](https://quay.io/repository/sclorg/varnish-6-c9s)
+* CentOS Stream 10 [varnish-6](https://quay.io/repository/sclorg/varnish-7-c10s)
 * Fedora [varnish-7](https://quay.io/repository/fedora/varnish-7)
 
 This repository contains Dockerfiles for Varnish HTTP accelerator images.
@@ -23,6 +24,7 @@ RHEL versions currently supported are:
 
 CentOS versions currently supported are:
 * CentOS Stream 9
+* CentOS Stream 10
 
 For more information about contributing, see
 [the Contribution Guidelines](https://github.com/sclorg/welcome/blob/master/contribution.md).
@@ -32,7 +34,7 @@ For more information about concepts used in these container images, see the
 
 Installation
 ---------------
-To build a Varnish image, choose either the CentOS or RHEL based image:
+To build a Varnish image, choose either the CentOS Stream or RHEL based image:
 * **RHEL based image**
 
     These images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/rhel8/varnish-6/5ba0ae68bed8bd6ee8198613?container-tabs=overview).

--- a/manifest.yml
+++ b/manifest.yml
@@ -35,6 +35,9 @@ DISTGEN_MULTI_RULES:
     dest: Dockerfile.c9s
 
   - src: src/Dockerfile.template
+    dest: Dockerfile.c10s
+
+  - src: src/Dockerfile.template
     dest: Dockerfile.fedora
 
 # Files to copy

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -43,7 +43,18 @@ specs:
       install_pkgs: "gettext hostname nss_wrapper bind-utils varnish gcc"
       img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
       etc_path: /etc
-
+    c10s:
+      distros:
+        - centos-stream-10-x86_64
+      el_version: "10"
+      s2i_base: quay.io/sclorg/s2i-core-c10s
+      img_tag: "c10s"
+      org: "sclorg"
+      from_tag: "c10s"
+      prod: "c10s"
+      install_pkgs: "gettext hostname nss_wrapper bind-utils varnish gcc"
+      img_name: "{{ spec.org }}/varnish-{{ spec.version }}-{{ spec.prod }}"
+      etc_path: /etc
   version:
     "6":
       version: "6"
@@ -59,4 +70,5 @@ matrix:
       version: "6"
     - distros:
         - fedora-38-x86_64
+        - centos-stream-10-xc86_64
       version: "7"

--- a/src/README.md
+++ b/src/README.md
@@ -67,5 +67,6 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/varnish-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
 Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`,
-Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`
+Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`,
+Dockerfile for CentOS Stream 10 is called `Dockerfile.c10s`
 and the Fedora Dockerfile is called Dockerfile.fedora.


### PR DESCRIPTION
This pull request is separated into two pull requests

- Add support for CentOS Stream 10 support
- Update documentation

This pull request is blocked by https://github.com/devexp-db/distgen/pull/142
