### PR TITLE
Building testing rhel10

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,1 @@
+target-branch: []

--- a/6/README.md
+++ b/6/README.md
@@ -66,7 +66,7 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/varnish-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`,
+Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`, for RHEL10 it's `Dockerfile.rhel10`,
 Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`,
 Dockerfile for CentOS Stream 10 is called `Dockerfile.c10s`
 and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/7/Dockerfile.rhel10
+++ b/7/Dockerfile.rhel10
@@ -1,0 +1,51 @@
+FROM ubi10/s2i-core:latest
+EXPOSE 8080
+EXPOSE 8443
+
+ENV SUMMARY="Platform for running Varnish or building Varnish-based application" \
+    DESCRIPTION="Varnish available as container is a base platform for \
+running Varnish server or building Varnish-based application. \
+Varnish Cache stores web pages in memory so web servers don't have to create \
+the same web page over and over again. Varnish Cache serves pages much faster \
+than any application server; giving the website a significant speed up." \
+    VARNISH_VCL=/etc/varnish/default.vcl \
+    VARNISH_CONFIGURATION_PATH=/etc/varnish \
+    VARNISH_VERSION=7
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Varnish 7" \
+      io.openshift.expose-services="8080:http,8443:https" \
+      io.openshift.tags="builder,varnish7,varnish-7" \
+      com.redhat.component="varnish-7-container" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      version="1" \
+      usage="s2i build https://github.com/sclorg/varnish-container.git --context-dir=7/test/test-app/ rhel10/varnish-7 sample-server" \
+      name="rhel10/varnish-7" \
+      maintainer="Uhliarik Lubos <luhliari@redhat.com>"
+
+RUN INSTALL_PKGS="gettext hostname nss_wrapper-libs bind-utils varnish gcc" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    fix-permissions $VARNISH_CONFIGURATION_PATH && \
+    fix-permissions /var/lib/varnish && \
+    varnishd -V 2>&1 | grep -qe "varnish-$VARNISH_VERSION\." && echo "Found VERSION $VARNISH_VERSION" && \
+    rm -f /etc/profile.d/lang.sh && \
+    rm -f /etc/profile.d/lang.csh && \
+    yum -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY 7/s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY 7/root/ /
+
+RUN chmod -R a+rwx ${APP_ROOT}/etc && \
+    chown -R 1001:0 ${APP_ROOT}
+# Reset permissions of filesystem to default values
+RUN rpm-file-permissions
+
+USER 1001
+
+CMD $STI_SCRIPTS_PATH/usage

--- a/7/README.md
+++ b/7/README.md
@@ -66,7 +66,7 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/varnish-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`,
+Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`, for RHEL10 it's `Dockerfile.rhel10`,
 Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`,
 Dockerfile for CentOS Stream 10 is called `Dockerfile.c10s`
 and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Varnish versions currently provided are:
 RHEL versions currently supported are:
 * RHEL8
 * RHEL9
+* RHEL10
 
 CentOS versions currently supported are:
 * CentOS Stream 9

--- a/manifest.yml
+++ b/manifest.yml
@@ -32,6 +32,9 @@ DISTGEN_MULTI_RULES:
     dest: Dockerfile.rhel9
 
   - src: src/Dockerfile.template
+    dest: Dockerfile.rhel10
+
+  - src: src/Dockerfile.template
     dest: Dockerfile.c9s
 
   - src: src/Dockerfile.template

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -31,6 +31,16 @@ specs:
       img_name: "{{ spec.prod }}/varnish-{{ spec.version }}"
       full_img_name: "{{ spec.img_name }}"
       etc_path: /etc
+    rhel10:
+      distros:
+        - rhel-10-x86_64
+      s2i_base: ubi10/s2i-core
+      from_tag: "latest"
+      prod: "rhel10"
+      install_pkgs: "gettext hostname nss_wrapper-libs bind-utils varnish gcc"
+      img_name: "{{ spec.prod }}/varnish-{{ spec.version }}"
+      full_img_name: "{{ spec.img_name }}"
+      etc_path: /etc
     c9s:
       distros:
         - centos-stream-9-x86_64
@@ -73,4 +83,5 @@ matrix:
     - distros:
         - fedora-39-x86_64
         - centos-stream-10-x86_64
+        - rhel-10-x86_64
       version: "7"

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -29,7 +29,7 @@ RUN INSTALL_PKGS="{{ spec.install_pkgs }}" && \
     {% endif %}
     {{ commands.pkginstaller.install([], {'docs': False}) }} $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    {% if config.os.id == "fedora" or spec.prod == "rhel8" or spec.prod == "rhel9" or spec.prod == "c9s" or spec.prod == "c10s" %}
+    {% if config.os.id == "fedora" or spec.prod == "rhel8" or spec.prod == "rhel9" or spec.prod == "rhel10" or spec.prod == "c9s" or spec.prod == "c10s" %}
     fix-permissions $VARNISH_CONFIGURATION_PATH && \
     fix-permissions /var/lib/varnish && \
     varnishd -V 2>&1 | grep -qe "varnish-$VARNISH_VERSION\." && echo "Found VERSION $VARNISH_VERSION" && \

--- a/src/README.md
+++ b/src/README.md
@@ -66,7 +66,7 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/varnish-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`,
+Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9`, for RHEL10 it's `Dockerfile.rhel10`,
 Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`,
 Dockerfile for CentOS Stream 10 is called `Dockerfile.c10s`
 and the Fedora Dockerfile is called Dockerfile.fedora.


### PR DESCRIPTION
The first commit adds sources for RHEL10
THe second commit adds generated files


<!-- issue-commentator = {"comment-id":"2624211200"} -->











































































































<!-- testing-farm = {"lock":"false","comment-id":"2624227067","data":[{"id":"452840b2-328a-4e62-b795-40558e8484eb","name":"CentOS Stream 10 - 7","status":"complete","outcome":"passed","runTime":370.081219,"created":"2025-01-30T15:23:53.722458","updated":"2025-01-30T15:23:53.722467","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/452840b2-328a-4e62-b795-40558e8484eb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/452840b2-328a-4e62-b795-40558e8484eb/pipeline.log\">pipeline</a>"]},{"id":"0f60cacf-c04c-4720-808e-1f00561318dd","name":"CentOS Stream 9 - 6","status":"complete","outcome":"passed","runTime":468.477377,"created":"2025-01-30T15:23:44.922310","updated":"2025-01-30T15:23:44.922318","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0f60cacf-c04c-4720-808e-1f00561318dd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0f60cacf-c04c-4720-808e-1f00561318dd/pipeline.log\">pipeline</a>"]},{"id":"2acd9184-dbe1-43cf-b2cf-ae1b7056689a","name":"Fedora - 7","status":"complete","outcome":"passed","runTime":611.966037,"created":"2025-01-30T15:23:47.825161","updated":"2025-01-30T15:23:47.825171","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2acd9184-dbe1-43cf-b2cf-ae1b7056689a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2acd9184-dbe1-43cf-b2cf-ae1b7056689a/pipeline.log\">pipeline</a>"]},{"id":"04969a56-9e60-4665-a7d3-7b30b373504c","name":"RHEL10 - 7","status":"complete","outcome":"passed","runTime":667.32385,"created":"2025-01-30T15:23:48.954921","updated":"2025-01-30T15:23:48.954931","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/04969a56-9e60-4665-a7d3-7b30b373504c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/04969a56-9e60-4665-a7d3-7b30b373504c/pipeline.log\">pipeline</a>"]},{"id":"1bfa0b07-f7e0-402a-b2fd-213b16eed721","name":"RHEL9 - 6","status":"complete","outcome":"passed","runTime":740.472894,"created":"2025-01-30T15:23:46.130897","updated":"2025-01-30T15:23:46.130908","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bfa0b07-f7e0-402a-b2fd-213b16eed721\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bfa0b07-f7e0-402a-b2fd-213b16eed721/pipeline.log\">pipeline</a>"]},{"id":"afbe7b1f-a2a0-4d1d-9166-d09aca986618","name":"RHEL8 - 6","runTime":912.49237,"created":"2025-01-30T15:23:45.608386","updated":"2025-01-30T15:23:45.608396","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/afbe7b1f-a2a0-4d1d-9166-d09aca986618\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/afbe7b1f-a2a0-4d1d-9166-d09aca986618/pipeline.log\">pipeline</a>"]}]} -->