### PR TITLE
Rename package bind-utils to bind9.18-utils

### DIFF
--- a/6/Dockerfile.rhel9
+++ b/6/Dockerfile.rhel9
@@ -25,7 +25,7 @@ LABEL summary="$SUMMARY" \
       name="rhel9/varnish-6" \
       maintainer="Uhliarik Lubos <luhliari@redhat.com>"
 
-RUN INSTALL_PKGS="gettext hostname nss_wrapper-libs bind-utils varnish gcc" && \
+RUN INSTALL_PKGS="gettext hostname nss_wrapper-libs bind9.18-utils varnish gcc" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     fix-permissions $VARNISH_CONFIGURATION_PATH && \

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -27,7 +27,7 @@ specs:
       s2i_base: ubi9/s2i-core
       from_tag: "1"
       prod: "rhel9"
-      install_pkgs: "gettext hostname nss_wrapper-libs bind-utils varnish gcc"
+      install_pkgs: "gettext hostname nss_wrapper-libs bind9.18-utils varnish gcc"
       img_name: "{{ spec.prod }}/varnish-{{ spec.version }}"
       full_img_name: "{{ spec.img_name }}"
       etc_path: /etc


### PR DESCRIPTION
Rename package bind-utils to bind9.18-utils

See Jira Ticket: https://issues.redhat.com/browse/RHEL-80345

<!-- issue-commentator = {"comment-id":"2740751982"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2740770752","data":[{"id":"60be093c-9f4e-4381-82f9-961b05b67b32","name":"CentOS Stream 10 - 7","status":"complete","outcome":"passed","runTime":257.487102,"created":"2025-03-21T10:27:16.548241","updated":"2025-03-21T10:27:16.548250","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/60be093c-9f4e-4381-82f9-961b05b67b32\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/60be093c-9f4e-4381-82f9-961b05b67b32/pipeline.log\">pipeline</a>"]},{"id":"27ab4fc3-0b3f-4464-80b2-491a139a6465","name":"CentOS Stream 9 - 6","status":"complete","outcome":"passed","runTime":326.258964,"created":"2025-03-21T10:27:16.381705","updated":"2025-03-21T10:27:16.381712","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/27ab4fc3-0b3f-4464-80b2-491a139a6465\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/27ab4fc3-0b3f-4464-80b2-491a139a6465/pipeline.log\">pipeline</a>"]},{"id":"12791b3a-9d54-4793-95af-fa65b328fc23","name":"Fedora - 7","status":"complete","outcome":"passed","runTime":426.192269,"created":"2025-03-21T10:27:16.549627","updated":"2025-03-21T10:27:16.549636","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/12791b3a-9d54-4793-95af-fa65b328fc23\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/12791b3a-9d54-4793-95af-fa65b328fc23/pipeline.log\">pipeline</a>"]},{"id":"9de8bae0-4439-4944-82fe-516b84115979","name":"RHEL10 - 7","status":"complete","outcome":"passed","runTime":747.670084,"created":"2025-03-21T10:27:15.613519","updated":"2025-03-21T10:27:15.613528","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9de8bae0-4439-4944-82fe-516b84115979\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9de8bae0-4439-4944-82fe-516b84115979/pipeline.log\">pipeline</a>"]},{"id":"18cbcfcd-baa5-4b04-8409-9ec78313e5fe","name":"RHEL9 - 6","status":"complete","outcome":"passed","runTime":786.109244,"created":"2025-03-21T10:27:16.518759","updated":"2025-03-21T10:27:16.518766","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/18cbcfcd-baa5-4b04-8409-9ec78313e5fe\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/18cbcfcd-baa5-4b04-8409-9ec78313e5fe/pipeline.log\">pipeline</a>"]},{"id":"78761970-74f6-4b09-9ab2-207c4f457a31","name":"RHEL8 - 6","runTime":914.287828,"created":"2025-03-21T12:37:05.274575","updated":"2025-03-21T12:37:05.274582","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/78761970-74f6-4b09-9ab2-207c4f457a31\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/78761970-74f6-4b09-9ab2-207c4f457a31/pipeline.log\">pipeline</a>"]}]} -->